### PR TITLE
fix(hugo.toml): update image source path to use a relative URL

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -88,7 +88,7 @@ darkmode = "dark"
     name = ""  # Empty name since we're using an image
     url = "/"
     weight = 0
-    pre = "<img src='https://redteamvillage.io/assets/images/2024-rtv-final-1-129x131.png' alt='RTV Logo' style='height: 40px; width: auto;'>"
+    pre = "<img src='assets/images/2024-rtv-final-1-129x131.png' alt='RTV Logo' style='height: 40px; width: auto;'>"
 
   [[menu.main]]
     identifier = "discord"


### PR DESCRIPTION
Change the image source path from an absolute URL to a relative URL to ensure the image loads correctly in different environments and improves portability. This change helps avoid potential issues with external resource loading and makes the site more self-contained.