### PR TITLE
fix(config.toml): set canonifyurls to true to ensure URLs are absolute

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,6 +40,9 @@ tagsLimit = 20
 # Always use dark mode
 darkmode = "dark"
 
+# BaseURL Fix
+canonifyurls = "true"
+
   [params.ad]
     # Google AdSense
     # ex. ca-pub-0000000000000000
@@ -88,7 +91,7 @@ darkmode = "dark"
     name = ""  # Empty name since we're using an image
     url = "/"
     weight = 0
-    pre = "<img src='assets/images/2024-rtv-final-1-129x131.png' alt='RTV Logo' style='height: 40px; width: auto;'>"
+    pre = "<img src='/assets/images/2024-rtv-final-1-129x131.png' alt='RTV Logo' style='height: 40px; width: auto;'>"
 
   [[menu.main]]
     identifier = "discord"


### PR DESCRIPTION
Setting `canonifyurls` to true ensures that all URLs are converted to absolute URLs, which is important for consistent linking across different environments. The image source path is corrected to be absolute, ensuring that the image loads correctly regardless of the current page's location.